### PR TITLE
Fix linked-list bugs

### DIFF
--- a/17-iterators-data-structures/10-linked-lists/script.js
+++ b/17-iterators-data-structures/10-linked-lists/script.js
@@ -21,6 +21,13 @@ class LinkedList {
 
   // Insert last node (Tail)
   insertLast(value) {
+
+    // Don't assume the list isn't empty.
+    if (!this._head) {
+      this.insertFirst(value);
+      return;
+    }
+
     const newNode = new Node(value);
     let current = this._head;
 
@@ -66,6 +73,7 @@ class LinkedList {
     while (current) {
       if (count === index) {
         console.log(current._value);
+        break;
       }
       count++;
       current = current.next;
@@ -75,7 +83,7 @@ class LinkedList {
 
   // Remove at index
   removeAt(index) {
-    if (index > this._length) {
+    if (index >= this._length) {
       return;
     }
 
@@ -101,10 +109,12 @@ class LinkedList {
   printListData() {
     let current = this._head;
     let list = '';
+    let separator = '';
 
     while (current) {
-      list += current._value + ' ';
+      list += separator + current._value;
       current = current.next;
+      separator = ' ';
     }
 
     console.log(list);
@@ -119,7 +129,8 @@ class LinkedList {
 
 const list = new LinkedList();
 
-list.insertFirst(100);
+list.insertLast(100);
+list.removeAt(1);  // Nothing to remove
 list.insertFirst(200);
 list.insertFirst(300);
 list.insertLast(50);


### PR DESCRIPTION
In section 17, session 10:
- `insertLast()` crashed if the list was empty
- `getAt()` kept going after finding the requested node
- `removeAt()` crashed if `index` equaled the number of nodes
- `printListData()` added a trailing space separator

I'm lumping multiple bugs into the same PR because there doesn't appear to be a way to file bug reports, to which I would have linked separate commits/PRs. I'm also ignoring the fact that `getAt()` doesn't do what its name says it will do.

Not all of the bugs were worth a PR, but with the two crashing bugs, I figured I might as well fix even the minor bugs while I had the code on the bench. 😉